### PR TITLE
Fix connectivity check for networks with packet loss

### DIFF
--- a/in-memory-network/src/network/mod.rs
+++ b/in-memory-network/src/network/mod.rs
@@ -312,26 +312,33 @@ impl InMemoryNetwork {
     ) -> anyhow::Result<(Duration, Duration)> {
         let peers = [(host_a, host_b), (host_b, host_a)];
 
-        // Send a packet both ways
+        // Send 100 packets both ways
+        //
+        // Note: This ensures that in case of packet loss on the network path the connectivity check still completes.
+        // To avoid spamming the console, we mute warnings for dropped packets.
+        *self.tracer.mute_warnings.lock() = true;
         for (source, target) in peers {
-            let data = self.in_transit_data(
-                source,
-                OwnedTransmit {
-                    destination: target.udp_endpoint.as_ref().unwrap().addr,
-                    ecn: None,
-                    contents: vec![42].into(),
-                    segment_size: None,
-                },
-            );
+            for _ in 0..100 {
+                let data = self.in_transit_data(
+                    source,
+                    OwnedTransmit {
+                        destination: target.udp_endpoint.as_ref().unwrap().addr,
+                        ecn: None,
+                        contents: vec![42].into(),
+                        segment_size: None,
+                    },
+                );
 
-            self.forward(source.clone(), data);
+                self.forward(source.clone(), data);
+            }
         }
+        *self.tracer.mute_warnings.lock() = false;
 
         // Wait for 90 days for the packets to arrive
         let days = 90;
         let timeout = Duration::from_secs(3600 * 24 * days);
 
-        // Ensure the packets arrived at each host
+        // Ensure the packets arrived at each host (1 succesfull delivery is sufficient)
         let a_to_b = async_rt::time::timeout(
             timeout,
             InboundQueue::receive(host_b.udp_endpoint.as_ref().unwrap().inbound.clone(), 1),

--- a/in-memory-network/src/tracing/tracer.rs
+++ b/in-memory-network/src/tracing/tracer.rs
@@ -20,6 +20,7 @@ pub struct SimulationStepTracer {
     recorded_steps: Mutex<SimulationStepper>,
     network_spec: NetworkSpec,
     already_warned_dropped_from_buffer: Mutex<HashSet<Arc<str>>>,
+    pub mute_warnings: Mutex<bool>,
 }
 
 impl SimulationStepTracer {
@@ -29,6 +30,7 @@ impl SimulationStepTracer {
             recorded_steps: Default::default(),
             network_spec: spec,
             already_warned_dropped_from_buffer: Mutex::default(),
+            mute_warnings: Mutex::new(false),
         }
     }
 
@@ -80,12 +82,14 @@ impl SimulationStepTracer {
             injected: true,
         }));
 
-        println!(
-            "{:.2}s WARN {} packet lost (#{})!",
-            self.simulation_start.elapsed().as_secs_f64(),
-            data.source_id,
-            data.number,
-        );
+        if !*self.mute_warnings.lock() {
+            println!(
+                "{:.2}s WARN {} packet lost (#{})!",
+                self.simulation_start.elapsed().as_secs_f64(),
+                data.source_id,
+                data.number,
+            );
+        }
     }
 
     pub fn track_dropped_from_buffer(&self, data: &InTransitData, current_node: &Node) {


### PR DESCRIPTION
Update `assert_connectivity_between_hosts` to send 100 packets instead of 1 to avoid problems in networks with packet loss. To suppress console spam for dropped packets during the check, a mutex was added to toggle off the warnings temporarily.

Fixes Issue #31