### PR TITLE
Make outbound rate limits per connection configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -299,12 +299,36 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -322,11 +346,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -393,12 +428,13 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash",
  "libm",
+ "portable-atomic",
  "rand",
  "siphasher",
 ]
@@ -414,6 +450,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
@@ -557,6 +605,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "iana-time-zone"
@@ -893,6 +947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,21 +988,20 @@ dependencies = [
 
 [[package]]
 name = "qlog"
-version = "0.15.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f15b83c59e6b945f2261c95a1dd9faf239187f32ff0a96af1d1d28c4557f919"
+checksum = "13932f4f3e6b912a43b3af40a3174614b8408c85059b79ef23fe1b3c87e5d04a"
 dependencies = [
+ "humantime",
  "serde",
  "serde_json",
  "serde_with",
- "smallvec",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+version = "0.12.0"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=dc8640052a64eb05b463b490b0a0a0f4b0cef9a6#dc8640052a64eb05b463b490b0a0a0f4b0cef9a6"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -960,9 +1019,8 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+version = "0.12.0"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=dc8640052a64eb05b463b490b0a0a0f4b0cef9a6#dc8640052a64eb05b463b490b0a0a0f4b0cef9a6"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -984,16 +1042,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+version = "0.6.1"
+source = "git+https://github.com/quinn-rs/quinn.git?rev=dc8640052a64eb05b463b490b0a0a0f4b0cef9a6#dc8640052a64eb05b463b490b0a0a0f4b0cef9a6"
 dependencies = [
  "cfg_aliases",
  "libc",
- "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1361,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64",
  "chrono",
@@ -1380,11 +1436,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1428,9 +1484,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ parking_lot = "0.12.3"
 pcap-file = "2.0.0"
 pin-project-lite = "0.2.16"
 pnet_packet = "0.34.0"
-quinn = "0.11"
-quinn-proto = { version = "0.11", features = ["qlog"] }
+quinn = "0.12"
+quinn-proto = { version = "0.12", features = ["qlog"] }
 quote = "1.0.40"
 rcgen = "0.13.1"
 rustls = { version = "0.23.8", default-features = false, features = ["ring"] }
@@ -38,3 +38,7 @@ uuid = { version = "1.11.0" }
 [profile.profiling]
 inherits = "release"
 debug = true
+
+[patch.crates-io]
+quinn = { git = "https://github.com/quinn-rs/quinn.git", rev = "dc8640052a64eb05b463b490b0a0a0f4b0cef9a6" }
+quinn-proto = { git = "https://github.com/quinn-rs/quinn.git", rev = "dc8640052a64eb05b463b490b0a0a0f4b0cef9a6" }

--- a/in-memory-network/src/lib.rs
+++ b/in-memory-network/src/lib.rs
@@ -262,7 +262,7 @@ mod test {
         let server_endpoint = Endpoint::new_with_abstract_socket(
             EndpointConfig::default(),
             Some(server_config),
-            Arc::new(
+            Box::new(
                 network
                     .udp_socket_for_node(server_socket.clone(), HOST_PORT)
                     .unwrap(),
@@ -270,10 +270,10 @@ mod test {
             rt.clone(),
         )
         .unwrap();
-        let mut client_endpoint = Endpoint::new_with_abstract_socket(
+        let client_endpoint = Endpoint::new_with_abstract_socket(
             EndpointConfig::default(),
             None,
-            Arc::new(
+            Box::new(
                 network
                     .udp_socket_for_node(client_socket.clone(), HOST_PORT)
                     .unwrap(),
@@ -343,7 +343,7 @@ mod test {
         network.forward(client_node.clone(), data);
 
         let mut recv_result = BufsAndMeta::new(1200, 10);
-        let server_socket = network
+        let mut server_socket = network
             .udp_socket_for_node(server_node.clone(), HOST_PORT)
             .unwrap();
         let received = server_socket.receive_raw(&mut recv_result).await.unwrap();
@@ -416,11 +416,9 @@ mod test {
         }
 
         let mut recv_result = BufsAndMeta::new(packet_size_bytes, 10);
-        let server_socket = Arc::new(
-            network
-                .udp_socket_for_node(server_node.clone(), HOST_PORT)
-                .unwrap(),
-        );
+        let mut server_socket = network
+            .udp_socket_for_node(server_node.clone(), HOST_PORT)
+            .unwrap();
         let mut received = 0;
         while received < 4 {
             received += server_socket.receive_raw(&mut recv_result).await.unwrap();
@@ -499,11 +497,9 @@ mod test {
 
         network.forward(client_node.clone(), data.clone());
         let mut recv_result = BufsAndMeta::new(1200, 10);
-        let server_socket = Arc::new(
-            network
-                .udp_socket_for_node(server_node.clone(), HOST_PORT)
-                .unwrap(),
-        );
+        let mut server_socket = network
+            .udp_socket_for_node(server_node.clone(), HOST_PORT)
+            .unwrap();
         let received = server_socket.receive_raw(&mut recv_result).await.unwrap();
 
         assert_eq!(received, 1);

--- a/in-memory-network/src/network/node.rs
+++ b/in-memory-network/src/network/node.rs
@@ -151,7 +151,7 @@ impl Node {
             .clone()
     }
 
-    pub(crate) fn enqueue_outbound(&self, network: &Arc<InMemoryNetwork>, packet: BufferedPacket) {
+    pub(crate) fn enqueue_outbound(&self, network: &InMemoryNetwork, packet: BufferedPacket) {
         // Try to enqueue the data on the node's outbound buffer for later sending
         let outbound_buffer = self.outbound_buffer();
         let data_len = packet.data.transmit.packet_size();

--- a/in-memory-network/src/quinn_interop.rs
+++ b/in-memory-network/src/quinn_interop.rs
@@ -5,7 +5,7 @@ use crate::transmit::{DEFAULT_TTL, OwnedTransmit};
 use bytes::Bytes;
 use parking_lot::Mutex;
 use quinn::udp::{RecvMeta, Transmit};
-use quinn::{AsyncUdpSocket, UdpPoller};
+use quinn::{AsyncUdpSocket, UdpSender};
 use std::fmt::{Debug, Formatter};
 use std::io;
 use std::io::IoSliceMut;
@@ -13,15 +13,6 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, ready};
-
-#[derive(Debug)]
-pub struct InMemoryUdpPoller;
-
-impl UdpPoller for InMemoryUdpPoller {
-    fn poll_writable(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-}
 
 pub struct InMemoryUdpSocket {
     network: Arc<InMemoryNetwork>,
@@ -52,17 +43,12 @@ impl InMemoryUdpSocket {
 }
 
 impl AsyncUdpSocket for InMemoryUdpSocket {
-    fn create_io_poller(self: Arc<Self>) -> Pin<Box<dyn UdpPoller>> {
-        Box::pin(InMemoryUdpPoller)
-    }
-
-    fn try_send(&self, transmit: &Transmit) -> io::Result<()> {
-        self.send(transmit);
-        Ok(())
+    fn create_sender(&self) -> Pin<Box<dyn UdpSender>> {
+        Box::pin(self.create_sender_concrete())
     }
 
     fn poll_recv(
-        &self,
+        &mut self,
         cx: &mut Context,
         bufs: &mut [IoSliceMut<'_>],
         meta: &mut [RecvMeta],
@@ -114,29 +100,25 @@ impl AsyncUdpSocket for InMemoryUdpSocket {
 }
 
 impl InMemoryUdpSocket {
+    pub fn create_sender_concrete(&self) -> InMemoryUdpSender {
+        InMemoryUdpSender {
+            network: self.network.clone(),
+            socket_addr: self.endpoint.addr,
+            node: self.node.clone(),
+        }
+    }
+
     pub fn send(&self, transmit: &Transmit) {
-        // We don't have code to handle GSO, so let's ensure transmits are always a single UDP
-        // packet
-        assert!(transmit.segment_size.is_none());
-
-        let transmit = OwnedTransmit {
-            source: self.endpoint.addr,
-            destination: transmit.destination,
-            ecn: transmit.ecn,
-            contents: Bytes::copy_from_slice(transmit.contents),
-            segment_size: transmit.segment_size,
-            ttl: DEFAULT_TTL,
-        };
-
-        // Track in pcap
-        self.node.pcap_exporter.track_transmit(&transmit);
-
-        let data = self.network.in_transit_data(self.node.id.clone(), transmit);
-        self.network.forward(self.node.clone(), data);
+        send(
+            self.node.clone(),
+            &self.network,
+            self.endpoint.addr,
+            transmit,
+        );
     }
 
     pub async fn receive<'a>(
-        &self,
+        &mut self,
         bufs_and_meta: &'a mut BufsAndMeta,
     ) -> io::Result<Vec<UdpPacket<'a>>> {
         let packets = self.receive_raw(bufs_and_meta).await?;
@@ -156,7 +138,7 @@ impl InMemoryUdpSocket {
         Ok(result)
     }
 
-    pub async fn receive_raw(&self, bufs_and_meta: &mut BufsAndMeta) -> io::Result<usize> {
+    pub async fn receive_raw(&mut self, bufs_and_meta: &mut BufsAndMeta) -> io::Result<usize> {
         let receive = UdpReceive {
             socket: self,
             result: bufs_and_meta,
@@ -166,13 +148,64 @@ impl InMemoryUdpSocket {
     }
 }
 
+fn send(node: Arc<Node>, network: &Arc<InMemoryNetwork>, source: SocketAddr, transmit: &Transmit) {
+    // We don't have code to handle GSO, so let's ensure transmits are always a single UDP
+    // packet
+    assert!(transmit.segment_size.is_none());
+
+    let transmit = OwnedTransmit {
+        source,
+        destination: transmit.destination,
+        ecn: transmit.ecn,
+        contents: Bytes::copy_from_slice(transmit.contents),
+        segment_size: transmit.segment_size,
+        ttl: DEFAULT_TTL,
+    };
+
+    // Track in pcap
+    node.pcap_exporter.track_transmit(&transmit);
+
+    let data = network.in_transit_data(node.id.clone(), transmit);
+
+    network.forward(node, data);
+}
+
+pub struct InMemoryUdpSender {
+    network: Arc<InMemoryNetwork>,
+    socket_addr: SocketAddr,
+    node: Arc<Node>,
+}
+
+impl Debug for InMemoryUdpSender {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("InMemoryUdpSender")
+    }
+}
+
+impl UdpSender for InMemoryUdpSender {
+    fn poll_send(
+        self: Pin<&mut Self>,
+        transmit: &Transmit<'_>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.send(transmit);
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl InMemoryUdpSender {
+    pub fn send(&self, transmit: &Transmit) {
+        send(self.node.clone(), &self.network, self.socket_addr, transmit);
+    }
+}
+
 pub struct UdpPacket<'a> {
     pub source_addr: SocketAddr,
     pub payload: &'a [u8],
 }
 
 pub struct UdpReceive<'a, 'b> {
-    socket: &'a dyn AsyncUdpSocket,
+    socket: &'a mut dyn AsyncUdpSocket,
     result: &'b mut BufsAndMeta,
 }
 

--- a/quinn-workbench/src/config/quinn.rs
+++ b/quinn-workbench/src/config/quinn.rs
@@ -33,6 +33,10 @@ pub struct QuinnJsonConfig {
     ///
     /// Defaults to `30_000` (30 seconds)
     pub maximum_idle_timeout_ms: Option<u64>,
+    /// The outbound rate limit (in bytes per second) for each connection.
+    ///
+    /// Defaults to no rate limiting other than what the congestion controller imposes.
+    pub maximum_outgoing_bytes_per_second: Option<u64>,
     /// Maximum reordering in packet numbers before considering a packet lost. Should not be less
     /// than 3, per RFC5681.
     ///

--- a/quinn-workbench/src/quic/client.rs
+++ b/quinn-workbench/src/quic/client.rs
@@ -200,10 +200,10 @@ pub fn client_endpoint(
     quinn_rng.fill(&mut seed);
 
     let qlog_file = File::create(format!("{}.qlog", client_socket.node_id()))?;
-    let mut endpoint = Endpoint::new_with_abstract_socket(
+    let endpoint = Endpoint::new_with_abstract_socket(
         crate::quic::endpoint_config(seed),
         None,
-        Arc::new(client_socket),
+        Box::new(client_socket),
         async_rt::active_rt(),
     )
     .context("failed to create client endpoint")?;

--- a/quinn-workbench/src/quic/mod.rs
+++ b/quinn-workbench/src/quic/mod.rs
@@ -36,6 +36,8 @@ fn transport_config(
         config.mtu_discovery_config(None);
     }
 
+    config.max_outgoing_bytes_per_second(quinn_config.maximum_outgoing_bytes_per_second);
+
     if let Some(timeout) = quinn_config.maximum_idle_timeout_ms {
         config.max_idle_timeout(Some(Duration::from_millis(timeout).try_into().unwrap()));
     }

--- a/quinn-workbench/src/quic/server.rs
+++ b/quinn-workbench/src/quic/server.rs
@@ -278,7 +278,7 @@ pub fn server_endpoint(
     Endpoint::new_with_abstract_socket(
         crate::quic::endpoint_config(seed),
         Some(server_config),
-        Arc::new(server_socket),
+        Box::new(server_socket),
         async_rt::active_rt(),
     )
     .context("failed to create server endpoint")

--- a/quinn-workbench/src/quinn_extensions/ecn_cc.rs
+++ b/quinn-workbench/src/quinn_extensions/ecn_cc.rs
@@ -39,12 +39,13 @@ impl Controller for EcnCc {
         now: Instant,
         sent: Instant,
         is_persistent_congestion: bool,
+        is_ecn: bool,
         lost_bytes: u64,
     ) {
-        // We ignore congestion events triggered by packet loss, forwarding only those triggered by ECN
-        if lost_bytes == 0 {
+        // Ignore congestion events triggered by packet loss, forward only those triggered by ECN
+        if is_ecn {
             self.0
-                .on_congestion_event(now, sent, is_persistent_congestion, lost_bytes)
+                .on_congestion_event(now, sent, is_persistent_congestion, is_ecn, lost_bytes)
         }
     }
 

--- a/quinn-workbench/src/quinn_extensions/no_cc.rs
+++ b/quinn-workbench/src/quinn_extensions/no_cc.rs
@@ -37,6 +37,7 @@ impl Controller for NoCC {
         _now: Instant,
         _sent: Instant,
         _is_persistent_congestion: bool,
+        _is_ecn: bool,
         _lost_bytes: u64,
     ) {
     }

--- a/quinn-workbench/src/udp/ping.rs
+++ b/quinn-workbench/src/udp/ping.rs
@@ -11,7 +11,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub fn run_server_forever(server_socket: InMemoryUdpSocket, client_socket: SocketAddr) {
+pub fn run_server_forever(mut server_socket: InMemoryUdpSocket, client_socket: SocketAddr) {
     async_rt::spawn(async move {
         let mut bufs_and_meta = BufsAndMeta::new(1200, 5);
 
@@ -34,12 +34,11 @@ pub fn run_server_forever(server_socket: InMemoryUdpSocket, client_socket: Socke
 }
 
 pub fn run_traffic_pattern(
-    client_socket: InMemoryUdpSocket,
+    mut client_socket: InMemoryUdpSocket,
     t: &PingTraffic,
     simulation_start: Instant,
     log_writer: Arc<Mutex<dyn Write + Sync + Send>>,
 ) -> async_rt::JoinHandle<()> {
-    let client_socket = Arc::new(client_socket);
     let interval = Duration::from_millis(t.send_interval_ms);
     let duration = Duration::from_millis(t.duration_ms);
     let deadline = Duration::from_millis(t.deadline_ms);
@@ -51,7 +50,7 @@ pub fn run_traffic_pattern(
     let (sender_done_tx, mut sender_done_rx) = futures::channel::oneshot::channel();
 
     // Sender
-    let client_socket_cp = client_socket.clone();
+    let client_socket_sender = client_socket.create_sender_concrete();
     let in_flight_cp = in_flight.clone();
     let lost_cp = lost.clone();
     let log_writer_cp = log_writer.clone();
@@ -69,7 +68,7 @@ pub fn run_traffic_pattern(
             // Send ping
             let payload = ping_nr.to_le_bytes();
 
-            client_socket_cp.send(&Transmit {
+            client_socket_sender.send(&Transmit {
                 destination: server_socket,
                 ecn: None,
                 contents: &payload,

--- a/quinn-workbench/src/udp/throughput.rs
+++ b/quinn-workbench/src/udp/throughput.rs
@@ -62,11 +62,9 @@ pub async fn run(
     let port = 8080;
     let server_ip = throughput_opt.peers.server_ip_address;
     let server_node = network.node(server_ip);
-    let server_socket = Arc::pin(
-        network
-            .udp_socket_for_node(server_node?.clone(), port)
-            .unwrap(),
-    );
+    let mut server_socket = network
+        .udp_socket_for_node(server_node?.clone(), port)
+        .unwrap();
 
     let client_ip = throughput_opt.peers.client_ip_address;
     let client_node = network.node(client_ip);
@@ -114,8 +112,8 @@ pub async fn run(
 
     println!("Sending at {send_bps} bps");
 
+    let client_socket_sender = client_socket.create_sender_concrete();
     let cancellation_token_cp = cancellation_token.clone();
-    let client_socket_cp = client_socket.clone();
     async_rt::spawn(async move {
         let max_bytes_per_transmit = 1200;
         let payload = vec![0; max_bytes_per_transmit];
@@ -131,7 +129,7 @@ pub async fn run(
                 bytes_left -= next_packet_size_bytes;
 
                 // Send packet
-                client_socket_cp.send(&Transmit {
+                client_socket_sender.send(&Transmit {
                     destination: SocketAddr::new(server_ip, 8080),
                     ecn: None,
                     contents: &payload[..next_packet_size_bytes],

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ After [installing Rust](https://rustup.rs/), you can get started:
 
 ```bash
 cd test-data/earth-spacecraft
-cargo run --release -- simulate 
+cargo run --release -- simulate
 ```
 By default, the tool uses the topology.json file in the current directory, implies that there are no events (interface up/down) and if no traffic.json file is specified, assumes a two nodes network with one link in between and tests a QUIC connection with 10 HTTP requests between the two nodes.
 
@@ -124,6 +124,8 @@ Here's the meaning of the different parameters:
   For continuous information exchange, use a small value to detect connection loss quickly. For
   delay-tolerant networking, use a very high value to prevent connection loss due to unexpected
   delays. Defaults to `30000` (30 seconds). Idle timeout is disabled when both endpoints omit this transport parameter or specify a value of 0.
+- `maximum_outgoing_bytes_per_second`: The outbound rate limit (in bytes per second) for each connection. Defaults to no
+  rate limiting other than what the congestion controller imposes.
 - `packet_threshold`: Maximum reordering in packet numbers before considering a packet lost.
   Should not be less than 3, as per RFC5681. Defaults to `3`.
 - `time_threshold`: Maximum time for a packet to be declared lost when a later packet has been acknowledged. See RFC9002 section 6.1.2. It is expressed as an RTT multiplier. Defaults to 9/8
@@ -233,7 +235,7 @@ Issues HTTP-like requests over QUIC from a client node to a server node. The fol
 - `concurrent_connections`: the number of concurrent connections used when making the requests [default: 1]. If set to > 1, then requests are sent in parallel on those connections.
 - `concurrent_streams_per_connection`: the number of concurrent streams per connection used when making the requests [default: 1]. If set to > 1, then requests are sent in parallel on those streams.
 - `response_size_bytes`: the size of each response, in bytes [default: 1024]. The response is synthesized by adding "Lorem ipsum" strings up to the size.
-- `request_interval_ms`: the number of milliseconds to wait between receiving a request's response and sending the next request (useful for checking if the connection gets terminated due to being idle) [default: 0]. When multiple connections are used, this interval is applied per connection (e.g., if two connections are active, two requests will be sent in parallel, then each connection will independently wait for the interval to elapse). If set to something other than `0`, requires that `concurrent_streams_per_connection` is `1`. 
+- `request_interval_ms`: the number of milliseconds to wait between receiving a request's response and sending the next request (useful for checking if the connection gets terminated due to being idle) [default: 0]. When multiple connections are used, this interval is applied per connection (e.g., if two connections are active, two requests will be sent in parallel, then each connection will independently wait for the interval to elapse). If set to something other than `0`, requires that `concurrent_streams_per_connection` is `1`.
 
 ## Command line arguments
 


### PR DESCRIPTION
The in-development version of quinn has support for rate-limiting outbound traffic. This PR makes that configurable in the workbench.