### PR TITLE
High Bandwidth Link PacketPacer

### DIFF
--- a/in-memory-network/src/network/inbound_queue.rs
+++ b/in-memory-network/src/network/inbound_queue.rs
@@ -21,10 +21,10 @@ impl InboundQueue {
         }
     }
 
-    pub(crate) fn send(&mut self, data: InTransitData, delay: Duration) {
+    pub(crate) fn send(&mut self, data: InTransitData, sent: Instant, delay: Duration) {
         self.queue.push(PrioritizedInTransitData {
             data,
-            sent: Instant::now(),
+            sent,
             delay,
         });
 

--- a/in-memory-network/src/network/link.rs
+++ b/in-memory-network/src/network/link.rs
@@ -243,7 +243,9 @@ impl NetworkLink {
             return false;
         }
 
-        self.pacer.lock().can_send(Instant::now())
+        let now = Instant::now();
+        let duration = self.pacer.lock().duration_until_can_send(now);
+        duration.is_zero()
     }
 
     pub(crate) fn next_delivered_packets(&mut self, max_transmits: usize) -> NextPacketDelivery {
@@ -271,30 +273,48 @@ impl PacketPacer {
     }
 
     fn can_send(&mut self, now: Instant) -> bool {
-        let Some(packet) = self.last_send.clone() else {
-            // No packet has been sent yet
-            return true;
-        };
-
-        packet.send_done <= now
+        // Allow sending if the debt is less than 1ms
+        self.duration_until_can_send(now).is_zero()
     }
 
     fn duration_until_can_send(&self, now: Instant) -> Duration {
         match &self.last_send {
             None => Duration::default(),
-            Some(p) => p
-                .send_done
-                .into_std()
-                .saturating_duration_since(now.into_std()),
+            Some(p) => {
+                let debt = p
+                    .send_done
+                    .into_std()
+                    .saturating_duration_since(now.into_std());
+                let threshold = Duration::from_millis(1);
+
+                if debt < threshold {
+                    Duration::default()
+                } else {
+                    // Sleep for the excess beyond the 1ms buffer.
+                    // This ensures the link stays saturated during the sleep.
+                    debt.saturating_sub(threshold)
+                }
+            }
         }
     }
 
     fn track_send(&mut self, now: Instant, packet_size_bytes: usize) {
         let packet_size_bits = packet_size_bytes.saturating_mul(8);
-        let send_duration_ms = packet_size_bits as f64 / self.bandwidth_bps * 1_000.0;
+        // Calculate transmission duration with nanosecond precision for high accuracy
+        let send_duration_ns =
+            packet_size_bits as f64 / self.bandwidth_bps * 1_000_000_000.0;
+        let duration = Duration::from_nanos(send_duration_ns.ceil() as u64);
+
+        // Determine the start time for this packet:
+        // If the link was idle, start now.
+        // If the link is still busy (send_done > now), start when the previous packet finishes.
+        let start_time = match &self.last_send {
+            Some(last) if last.send_done > now => last.send_done,
+            _ => now,
+        };
 
         self.last_send = Some(SendingPacket {
-            send_done: now + Duration::from_millis(send_duration_ms.ceil() as u64),
+            send_done: start_time + duration,
         });
     }
 }

--- a/in-memory-network/src/network/link.rs
+++ b/in-memory-network/src/network/link.rs
@@ -159,19 +159,21 @@ impl NetworkLink {
             data.transmit.ecn = Some(EcnCodepoint::from_bits(0b11).unwrap())
         }
 
-        // Record
+        // Trace
         self.tracer.track_packet_in_transit(src_node, self, &data);
 
         // Send
-        self.pacer
-            .lock()
-            .track_send(Instant::now(), data.transmit.packet_size());
+        // Track send on link and get virtual completion time
+        let tx_completion_time = self.pacer.lock().track_send(Instant::now(), data.transmit.packet_size());
+        // Release buffer
         src_node
             .outbound_buffer()
             .release(data.transmit.packet_size());
+
+        // Pass the completion time as the "sent" timestamp to inbound queue
         self.in_transit
             .lock()
-            .send(data, self.delay + anomalies.extra_delay);
+            .send( data, tx_completion_time,self.delay + anomalies.extra_delay);
     }
 
     pub(crate) async fn sleep_until_ready_to_send(
@@ -298,7 +300,7 @@ impl PacketPacer {
         }
     }
 
-    fn track_send(&mut self, now: Instant, packet_size_bytes: usize) {
+    fn track_send(&mut self, now: Instant, packet_size_bytes: usize) -> Instant {
         let packet_size_bits = packet_size_bytes.saturating_mul(8);
         // Calculate transmission duration with nanosecond precision for high accuracy
         let send_duration_ns =
@@ -313,9 +315,12 @@ impl PacketPacer {
             _ => now,
         };
 
+        let completion_time = start_time + duration;
         self.last_send = Some(SendingPacket {
-            send_done: start_time + duration,
+            send_done: completion_time,
         });
+
+        completion_time
     }
 }
 

--- a/in-memory-network/src/network/mod.rs
+++ b/in-memory-network/src/network/mod.rs
@@ -497,7 +497,7 @@ impl InMemoryNetwork {
                 .inbound
                 .clone()
                 .lock()
-                .send(data, Duration::default());
+                .send(data, Instant::now(), Duration::default());
 
             return;
         }


### PR DESCRIPTION
### Summary
This update transitions the network link pacing from a "sleep-per-packet" model to a debt-based leaky bucket approach. This change should solve issue #53. By calculating a "virtual completion time" for each packet, the simulation can now process large batches of data within a single 1ms tick while still enforcing the configured bit-rate over time.

### Key Changes
- PacketPacer Redesign: Replaced per-packet serialization sleeps with a `next_available_time` tracker that manages "debt" (the time required to push bits onto the wire).
- Batching: Introduced a 1ms debt threshold in `PacketPacer::duration_until_can_send`. This allows the pacer to "borrow" up to 1ms of future capacity, enabling it to process multiple packets (in high bandwidth scenarios, where a packet takes less than a ms) instantly before schdeuling a sleep.
- Virtual Timing at Receiver: `PacketPacer::track_send `now returns the exact virtual completion time for each packet. This timestamp is passed to the InboundQueue, ensuring that packets arrive at the destination with realistic spacing and correct ordering, even if they were processed in a burst by the pacer.
- Enhanced Precision: Serialization delays are now calculated with nanosecond precision to avoid inaccuracies in high bandwidth scenarios.

### Known Issues
Looking at the verifier stats, the link capacity is currently exceeded by a tiny margin. Mathematically, the approach is valid for enforcing the average bit-rate; however, the 1ms debt threshold allows small "bursts" of data to enter the transit queue slightly ahead of their actual virtual time, which may be detected as a slight overage by the verifier.