### PR TITLE
Simplify generation of synthetic pcap files

### DIFF
--- a/in-memory-network/src/network/node.rs
+++ b/in-memory-network/src/network/node.rs
@@ -105,7 +105,9 @@ impl Node {
         let keylog = Arc::new(InMemoryKeyLog::default());
         let pcap_exporter = match pcap_options {
             PcapOptions::Disabled => PcapExporter::noop(),
-            PcapOptions::WithTlsKeys => PcapExporter::for_node(&node.id, Some(keylog.clone()))?,
+            PcapOptions::WithTlsKeys => {
+                PcapExporter::for_node(node.id.clone(), Some(keylog.clone()))?
+            }
         };
 
         let (tx, rx) = futures::channel::mpsc::unbounded();

--- a/in-memory-network/src/pcap_exporter.rs
+++ b/in-memory-network/src/pcap_exporter.rs
@@ -1,11 +1,11 @@
 use crate::async_rt::time::Instant;
-use crate::transmit::{DEFAULT_TTL, OwnedTransmit};
+use crate::transmit::OwnedTransmit;
 use anyhow::Context;
 use parking_lot::Mutex;
 use pcap_file::pcapng::blocks::enhanced_packet::EnhancedPacketBlock;
 use pcap_file::pcapng::blocks::interface_description::InterfaceDescriptionBlock;
 use pcap_file::pcapng::blocks::section_header::SectionHeaderBlock;
-use pcap_file::pcapng::{PcapNgWriter, RawBlock};
+use pcap_file::pcapng::{PcapNgReader, PcapNgWriter, RawBlock};
 use pcap_file::{DataLink, Endianness};
 use pnet_packet::ip::IpNextHeaderProtocol;
 use pnet_packet::ipv4::MutableIpv4Packet;
@@ -13,12 +13,14 @@ use pnet_packet::udp::MutableUdpPacket;
 use pnet_packet::{PacketSize, ipv4, udp};
 use rustls::KeyLog;
 use std::fmt::{Debug, Formatter};
-use std::fs;
+use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::net::IpAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+use std::{fs, mem};
 
 #[derive(Default)]
 pub struct InMemoryKeyLog {
@@ -41,127 +43,169 @@ impl KeyLog for InMemoryKeyLog {
     }
 }
 
+fn pcap_writer(
+    writer: Box<dyn Write + Send + Sync + 'static>,
+    add_interface_description: bool,
+) -> anyhow::Result<PcapNgWriter<Box<dyn Write + Send + Sync + 'static>>> {
+    let mut writer = PcapNgWriter::with_section_header(
+        writer,
+        SectionHeaderBlock {
+            endianness: Endianness::Big,
+            major_version: 1,
+            minor_version: 0,
+            section_length: 0,
+            options: vec![],
+        },
+    )?;
+
+    if add_interface_description {
+        writer.write_pcapng_block(InterfaceDescriptionBlock {
+            linktype: DataLink::IPV4,
+            snaplen: 65535,
+            options: vec![],
+        })?;
+    }
+
+    Ok(writer)
+}
+
 pub struct PcapExporter {
     capture_start: Instant,
     total_tracked_packets: AtomicU64,
-    writer: Mutex<PcapNgWriter<BufWriter<Box<dyn Write + Send + Sync + 'static>>>>,
-    buffered_packets: Mutex<Vec<(OwnedTransmit, Instant)>>,
     keylog: Option<Arc<InMemoryKeyLog>>,
-    keylog_written: AtomicBool,
+    tmp_writer: Mutex<PcapNgWriter<Box<dyn Write + Send + Sync + 'static>>>,
+    node_id: Option<Arc<str>>,
 }
 
 impl PcapExporter {
-    pub fn new(
-        writer: impl Write + Send + Sync + 'static,
-        keylog: Option<Arc<InMemoryKeyLog>>,
-    ) -> Self {
-        let writer: Box<dyn Write + Send + Sync + 'static> = Box::new(writer);
-        let mut writer = PcapNgWriter::with_section_header(
-            BufWriter::new(writer),
-            SectionHeaderBlock {
-                endianness: Endianness::Big,
-                major_version: 1,
-                minor_version: 0,
-                section_length: 0,
-                options: vec![],
-            },
-        )
-        .unwrap();
-
-        writer
-            .write_pcapng_block(InterfaceDescriptionBlock {
-                linktype: DataLink::IPV4,
-                snaplen: 65535,
-                options: vec![],
-            })
-            .unwrap();
-
-        Self {
+    pub fn new(node_name: Arc<str>, keylog: Option<Arc<InMemoryKeyLog>>) -> anyhow::Result<Self> {
+        let file_path = Self::tmp_path(&node_name);
+        let file = File::create(&file_path)
+            .with_context(|| format!("failed to open {} for writing", file_path.display()))?;
+        let writer = pcap_writer(Box::new(BufWriter::new(file)), true)?;
+        Ok(Self {
             capture_start: Instant::now(),
-            writer: Mutex::new(writer),
+            tmp_writer: Mutex::new(writer),
+            node_id: Some(node_name),
             total_tracked_packets: AtomicU64::new(0),
-            buffered_packets: Mutex::default(),
             keylog,
-            keylog_written: AtomicBool::new(false),
-        }
+        })
     }
 
-    pub fn for_node(node_id: &str, keylog: Option<Arc<InMemoryKeyLog>>) -> anyhow::Result<Self> {
-        let file_name = format!("{node_id}.pcap");
-        let pcap_file = fs::File::create(&file_name)
-            .with_context(|| format!("failed to open {file_name} for writing"))?;
-        Ok(PcapExporter::new(pcap_file, keylog))
+    pub fn for_node(
+        node_id: Arc<str>,
+        keylog: Option<Arc<InMemoryKeyLog>>,
+    ) -> anyhow::Result<Self> {
+        PcapExporter::new(node_id, keylog)
     }
 
     pub fn noop() -> Self {
-        Self::new(std::io::sink(), None)
+        Self {
+            capture_start: Instant::now(),
+            tmp_writer: Mutex::new(Self::noop_writer()),
+            node_id: None,
+            total_tracked_packets: AtomicU64::new(0),
+            keylog: None,
+        }
+    }
+
+    fn finish(&self) -> anyhow::Result<()> {
+        // Finish writing the tmp file
+        let writer = mem::replace(&mut *self.tmp_writer.lock(), Self::noop_writer());
+        let mut writer = writer.into_inner();
+        writer.flush()?;
+        drop(writer);
+
+        // Now let's write the final file if a node id was available
+
+        let Some(node_id) = &self.node_id else {
+            // No node id, so no file
+            return Ok(());
+        };
+
+        let tmp_path = Self::tmp_path(node_id);
+        let final_path = Self::final_path(node_id);
+
+        let Some(keylog) = &self.keylog else {
+            // No keylog, so the original tmp file can be reused unmodified
+            fs::rename(&tmp_path, &final_path)?;
+            return Ok(());
+        };
+
+        // Copy tmp file to final file, but prepending the keylog block before anything else
+        let tmp_file = File::open(&tmp_path)
+            .with_context(|| format!("failed to open {}", tmp_path.display()))?;
+        let mut tmp_reader = PcapNgReader::new(tmp_file)?;
+
+        let final_file = File::create(&final_path)
+            .with_context(|| format!("failed to open {}", final_path.display()))?;
+        let mut final_writer = pcap_writer(Box::new(BufWriter::new(final_file)), false)?;
+
+        Self::write_keylog_pcap_block(&mut final_writer, keylog)?;
+        while let Some(block) = tmp_reader.next_raw_block() {
+            final_writer.write_raw_block(&block?)?;
+        }
+
+        // Delete the tmp file
+        drop(tmp_reader);
+        fs::remove_file(&tmp_path)?;
+
+        final_writer.into_inner().flush()?;
+
+        Ok(())
+    }
+
+    fn noop_writer() -> PcapNgWriter<Box<dyn Write + Send + Sync + 'static>> {
+        pcap_writer(Box::new(std::io::sink()), true).unwrap()
+    }
+
+    fn final_path(node_id: &str) -> PathBuf {
+        format!("{node_id}.pcap").into()
+    }
+
+    fn tmp_path(node_id: &str) -> PathBuf {
+        format!("{node_id}.pcap.tmp").into()
+    }
+
+    fn write_keylog_pcap_block(
+        writer: &mut PcapNgWriter<Box<dyn Write + Send + Sync + 'static>>,
+        keylog: &InMemoryKeyLog,
+    ) -> anyhow::Result<()> {
+        let mut secrets = keylog.log.lock().join("\n");
+        secrets.push('\n');
+
+        let mut block = Vec::new();
+
+        let block_type: u32 = 0x0000000A;
+        block.extend_from_slice(&block_type.to_be_bytes());
+
+        // Save space for length
+        let length_offset = block.len();
+        block.extend_from_slice(&[0, 0, 0, 0]);
+
+        let secrets_type: u32 = 0x544c534b;
+        block.extend_from_slice(&secrets_type.to_be_bytes());
+
+        let secrets_length = secrets.len() as u32;
+        block.extend_from_slice(&secrets_length.to_be_bytes());
+        block.extend_from_slice(secrets.as_bytes());
+
+        // Pad to 4-byte boundary
+        while block.len() % 4 != 0 {
+            block.push(0x00);
+        }
+
+        let total_length = block.len() as u32 + 4;
+        block.extend_from_slice(&total_length.to_be_bytes());
+
+        block[length_offset..length_offset + 4].copy_from_slice(&total_length.to_be_bytes());
+
+        let (_, raw_block) = RawBlock::from_slice::<byteorder::BigEndian>(&block)?;
+        writer.write_raw_block(&raw_block)?;
+        Ok(())
     }
 
     pub fn track_transmit(&self, transmit: &OwnedTransmit) {
-        if let Some(keylog) = &self.keylog
-            && let log = keylog.log.lock()
-            && let keylog_written = self.keylog_written.load(Ordering::Relaxed)
-            && !keylog_written
-        {
-            // Buffer packets internally if not enough key material is present to decrypt them yet
-            if log.len() < 5 {
-                self.buffered_packets.lock().push((
-                    OwnedTransmit {
-                        source: transmit.source,
-                        destination: transmit.destination,
-                        ecn: transmit.ecn,
-                        contents: transmit.contents.clone(),
-                        segment_size: transmit.segment_size,
-                        ttl: DEFAULT_TTL,
-                    },
-                    Instant::now(),
-                ));
-
-                return;
-            } else {
-                self.keylog_written.store(true, Ordering::Relaxed);
-
-                let mut secrets = log.join("\n");
-                secrets.push('\n');
-
-                let mut block = Vec::new();
-
-                let block_type: u32 = 0x0000000A;
-                block.extend_from_slice(&block_type.to_be_bytes());
-
-                // Save space for length
-                let length_offset = block.len();
-                block.extend_from_slice(&[0, 0, 0, 0]);
-
-                let secrets_type: u32 = 0x544c534b;
-                block.extend_from_slice(&secrets_type.to_be_bytes());
-
-                let secrets_length = secrets.len() as u32;
-                block.extend_from_slice(&secrets_length.to_be_bytes());
-                block.extend_from_slice(secrets.as_bytes());
-
-                // Pad to 4-byte boundary
-                while block.len() % 4 != 0 {
-                    block.push(0x00);
-                }
-
-                let total_length = block.len() as u32 + 4;
-                block.extend_from_slice(&total_length.to_be_bytes());
-
-                block[length_offset..length_offset + 4]
-                    .copy_from_slice(&total_length.to_be_bytes());
-
-                let (_, raw_block) = RawBlock::from_slice::<byteorder::BigEndian>(&block).unwrap();
-
-                self.writer.lock().write_raw_block(&raw_block).unwrap();
-
-                // Write previously buffered packets
-                for (transmit, sent) in std::mem::take(&mut *self.buffered_packets.lock()) {
-                    self.write_pcapng_transmit(&transmit, sent);
-                }
-            }
-        }
-
         self.write_pcapng_transmit(transmit, Instant::now());
     }
 
@@ -213,7 +257,7 @@ impl PcapExporter {
 
         self.total_tracked_packets.fetch_add(1, Ordering::Relaxed);
 
-        self.writer
+        self.tmp_writer
             .lock()
             .write_pcapng_block(EnhancedPacketBlock {
                 interface_id: 0,
@@ -228,9 +272,8 @@ impl PcapExporter {
 
 impl Drop for PcapExporter {
     fn drop(&mut self) {
-        let packets = std::mem::take(&mut *self.buffered_packets.lock());
-        for (transmit, sent) in packets {
-            self.write_pcapng_transmit(&transmit, sent);
+        if let Err(e) = self.finish() {
+            eprintln!("failed to finish pcap exporter: {e:?}");
         }
     }
 }


### PR DESCRIPTION
Since we simulate the QUIC protocol (among others), we need a way to inject a connection's encryption keys into the pcap (otherwise tools like Wireshark are unable to actually decrypt the packets and display their contents).

In the past, we discovered that key material needs to be placed at the beginning of the pcap file for Wireshark to properly decrypt packets. Hence, we devised a somewhat complex mechanism to buffer up pcap blocks until enough key material was present. That wasn't particularly robust so we now replaced it by something more bulletproof: we write a temporary pcap file until the network shuts down. Only then we write a new pcap file which is equivalent to the temporary one but has the keys prepended.