### PR TITLE
add pad_to_mtu option in quic json config

### DIFF
--- a/quinn-workbench/src/config/quinn.rs
+++ b/quinn-workbench/src/config/quinn.rs
@@ -66,6 +66,10 @@ pub struct QuinnJsonConfig {
     ///
     /// Defaults to 9/8 (in RFC9002)
     pub time_threshold: Option<f32>,
+    /// Whether to add padding to every packet to make trafic analysis more difficult
+    /// see RFC9002 section 8.2
+    /// default is off
+    pub pad_to_mtu: Option<bool>,
 }
 
 #[derive(Deserialize, Clone, Default)]

--- a/quinn-workbench/src/quic/mod.rs
+++ b/quinn-workbench/src/quic/mod.rs
@@ -57,6 +57,10 @@ fn transport_config(
         config.time_threshold(time_threshold);
     }
 
+    if let Some(pad_to_mtu) = quinn_config.pad_to_mtu {
+        config.pad_to_mtu(pad_to_mtu);
+    }
+
     let get_congestion_window_bytes = |packets: u64| packets * BASE_DATAGRAM_SIZE;
     let cc_factory: Arc<dyn quinn_proto::congestion::ControllerFactory + Send + Sync> =
         match quinn_config

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ Here's the meaning of the different parameters:
   times the base datagram size (1200 bytes). The default depends on the congestion control
   algorithm. For `no_cc`, the default is effectively unlimited. For other algorithms, the default is
   a value suitable for terrestrial communication.
+- `pad_to_mtu`: Boolean flag to add padding up to MTU to make traffic analysis more difficult. Default is `false`.
 
 ###### Links
 
@@ -154,7 +155,6 @@ Each link is defined with the following properties:
   artificially introduce packet reordering (the value must be between 0 and 1). Default is 0. This is similar to [tc netem reorder parameter](https://man7.org/linux/man-pages/man8/tc-netem.8.html).
 - `congestion_event_ratio`: The ratio of packets that will be marked with a CE ECN codepoint
   (the value must be between 0 and 1). Default is 0.
-
 
 ## Network events configuration
 


### PR DESCRIPTION
expose (another) Quinn transport config parameter (pad_to_mtu) to our json config file.