### PR TITLE
keep_alive_interval_ms added in quic config

### DIFF
--- a/quinn-workbench/src/config/quinn.rs
+++ b/quinn-workbench/src/config/quinn.rs
@@ -71,6 +71,9 @@ pub struct QuinnJsonConfig {
     ///
     /// Defaults to `false`
     pub pad_to_mtu: Option<bool>,
+    /// Period of inactivity before sending a keep-alive packet
+    /// Defaults to None which disables it
+    pub keep_alive_interval_ms: Option<u64>,
 }
 
 #[derive(Deserialize, Clone, Default)]

--- a/quinn-workbench/src/quic/mod.rs
+++ b/quinn-workbench/src/quic/mod.rs
@@ -65,7 +65,6 @@ fn transport_config(
         config.keep_alive_interval(Some(Duration::from_millis(keep_alive).try_into().unwrap()));
     }
 
-
     let get_congestion_window_bytes = |packets: u64| packets * BASE_DATAGRAM_SIZE;
     let cc_factory: Arc<dyn quinn_proto::congestion::ControllerFactory + Send + Sync> =
         match quinn_config

--- a/quinn-workbench/src/quic/mod.rs
+++ b/quinn-workbench/src/quic/mod.rs
@@ -62,8 +62,7 @@ fn transport_config(
     }
 
     if let Some(keep_alive) = quinn_config.keep_alive_interval_ms {
-        config.keep_alive_interval(
-            Some(Duration::from_millis(keep_alive).try_into().unwrap()));
+        config.keep_alive_interval(Some(Duration::from_millis(keep_alive).try_into().unwrap()));
     }
 
 

--- a/quinn-workbench/src/quic/mod.rs
+++ b/quinn-workbench/src/quic/mod.rs
@@ -61,6 +61,12 @@ fn transport_config(
         config.pad_to_mtu(pad_to_mtu);
     }
 
+    if let Some(keep_alive) = quinn_config.keep_alive_interval_ms {
+        config.keep_alive_interval(
+            Some(Duration::from_millis(keep_alive).try_into().unwrap()));
+    }
+
+
     let get_congestion_window_bytes = |packets: u64| packets * BASE_DATAGRAM_SIZE;
     let cc_factory: Arc<dyn quinn_proto::congestion::ControllerFactory + Send + Sync> =
         match quinn_config


### PR DESCRIPTION
direct map with Quinn keep_alive_interval transport config parameter